### PR TITLE
User-data update to 3.1.0 IGN

### DIFF
--- a/registry-node/registry-node.tf
+++ b/registry-node/registry-node.tf
@@ -30,7 +30,8 @@ resource "aws_instance" "registry-node" {
   ami = var.rhcos_ami
   instance_type = var.registry_type
   subnet_id = local.instance_subnet_id
-  user_data = "{\"ignition\":{\"config\":{},\"security\":{\"tls\":{}},\"timeouts\":{},\"version\":\"2.2.0\"},\"networkd\":{},\"passwd\":{\"users\":[{\"name\":\"core\",\"sshAuthorizedKeys\":[\"${var.ssh_public_key}\"]}]},\"storage\":{},\"systemd\":{}}"
+  user_data = "{\"ignition\": {\"version\":\"3.1.0\"},\"passwd\":{\"users\":[{\"name\": \"core\",\"passwordHash\": \"\",\"sshAuthorizedKeys\":[\"${var.ssh_public_key}\"]}]}}"
+
 
   root_block_device { volume_size = var.registry_volume }
   security_groups = var.registry_sg_ids


### PR DESCRIPTION
Updated the user-data to utilize the 3.1.0 syntax to deploy the registry node. 

Verified by: 
1. Pull code and deploy devkit-vpc. 
2. Login to bastion and ssh to the registry node. Uses the pub/private key associated in the variables.tf requirements.  