### PR TITLE
Removing interpolated variable

### DIFF
--- a/vpc/vpc.tf
+++ b/vpc/vpc.tf
@@ -7,7 +7,7 @@ resource "aws_vpc" "cluster_vpc" {
   tags = merge(
   var.default_tags,
     map(
-    "Name", "${var.cluster_name}",
+    "Name", var.cluster_name,
     "kubernetes.io/cluster/${var.cluster_name}", "owned"
     )
   )


### PR DESCRIPTION
Removing static variable interpolation.  This is something that Terraform throws up warnings in recent versions.  May not be compatible with older versions of terraform, but neither is the other code (for example, we're using expressions).  I have tested this on AWS Region gov-east-1 and it worked without issue