### PR TITLE
updates to get names of public subnets correct

### DIFF
--- a/vpc/public-subnet.tf
+++ b/vpc/public-subnet.tf
@@ -13,7 +13,7 @@ resource "aws_subnet" "public-subnet" {
   tags = merge(
     var.default_tags,
     map(
-      "Name", format("${var.cluster_name}-public-%s", format("%s%s", element(list(var.aws_region), 0), element(var.aws_azs, 0))),
+      "Name", format("${var.cluster_name}-public-%s", format("%s%s", element(list(var.aws_region), count.index), element(var.aws_azs, count.index))),
       "kubernetes.io/cluster/${var.cluster_name}", "owned"
     )
   )


### PR DESCRIPTION
This minor fix will adjust the names of the subnets to iterate over the array, similar to what is being done for the private subnets